### PR TITLE
Add device info for MetService entities

### DIFF
--- a/custom_components/metservice_weather/const.py
+++ b/custom_components/metservice_weather/const.py
@@ -9,6 +9,7 @@ from typing import Final
 
 DOMAIN = "metservice_weather"
 CONF_ATTRIBUTION = "Data provided by the MetService NZ weather service"
+MANUFACTURER = "MetService"
 
 FIELD_DESCRIPTION = "wxPhraseLong"
 FIELD_HUMIDITY = "relativeHumidity"

--- a/custom_components/metservice_weather/sensor.py
+++ b/custom_components/metservice_weather/sensor.py
@@ -10,11 +10,12 @@ import logging
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.unit_system import METRIC_SYSTEM
-from homeassistant.helpers.typing import StateType
 
 from typing import Any
 
@@ -23,9 +24,10 @@ from .coordinator import WeatherUpdateCoordinator
 from .const import (
     CONF_ATTRIBUTION,
     DOMAIN,
-    SENSOR_MAP_PUBLIC,
-    SENSOR_MAP_MOBILE,
+    MANUFACTURER,
     RESULTS_CURRENT,
+    SENSOR_MAP_MOBILE,
+    SENSOR_MAP_PUBLIC,
 )
 from .weather_current_conditions_sensors import (
     current_condition_sensor_descriptions_public,
@@ -78,6 +80,12 @@ class WeatherSensor(CoordinatorEntity, SensorEntity):
         """Initialize MetService sensors."""
         super().__init__(coordinator)
         self.entity_description = description
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.location)},
+            name=coordinator.location_name,
+            manufacturer=MANUFACTURER,
+        )
 
         entity_id_format = description.key + ".{}"
 

--- a/custom_components/metservice_weather/weather.py
+++ b/custom_components/metservice_weather/weather.py
@@ -8,16 +8,17 @@ from . import WeatherUpdateCoordinator
 from homeassistant.config_entries import ConfigEntry
 from .const import (
     DOMAIN,
-    TEMPUNIT,
-    LENGTHUNIT,
-    SPEEDUNIT,
-    PRESSUREUNIT,
     FIELD_CONDITIONS,
     FIELD_HUMIDITY,
     FIELD_PRESSURE,
     FIELD_TEMP,
     FIELD_WINDDIR,
     FIELD_WINDSPEED,
+    LENGTHUNIT,
+    MANUFACTURER,
+    PRESSUREUNIT,
+    SPEEDUNIT,
+    TEMPUNIT,
     CONDITION_MAP,
 )
 
@@ -39,6 +40,7 @@ from homeassistant.components.weather import (
 )
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -75,6 +77,15 @@ async def async_setup_entry(
 
 class MetServiceMobile(SingleCoordinatorWeatherEntity):
     """Implementation of a MetService weather service."""
+
+    def __init__(self, coordinator: WeatherUpdateCoordinator) -> None:
+        """Set up MetService device info."""
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.location)},
+            name=coordinator.location_name,
+            manufacturer=MANUFACTURER,
+        )
 
     @property
     def native_temperature(self) -> float:
@@ -252,6 +263,15 @@ class MetServiceForecastMobile(MetServiceMobile):
 
 class MetServicePublic(SingleCoordinatorWeatherEntity):
     """Implementation of a MetService weather service."""
+
+    def __init__(self, coordinator: WeatherUpdateCoordinator) -> None:
+        """Set up MetService device info."""
+        super().__init__(coordinator)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.location)},
+            name=coordinator.location_name,
+            manufacturer=MANUFACTURER,
+        )
 
     @property
     def native_temperature(self) -> float:


### PR DESCRIPTION
Rolls up all of the entities into a single virtual "device". This makes management of multiple instances of the integration much easier.

<img width="1004" height="804" alt="Screenshot 2025-08-13 at 16 58 03" src="https://github.com/user-attachments/assets/4a36aaea-e32d-46e1-a1ae-885439673ce7" />
