### PR TITLE
Fix invalid entity ID format causing HomeAssistantError

### DIFF
--- a/custom_components/metservice_weather/sensor.py
+++ b/custom_components/metservice_weather/sensor.py
@@ -87,7 +87,7 @@ class WeatherSensor(CoordinatorEntity, SensorEntity):
             manufacturer=MANUFACTURER,
         )
 
-        entity_id_format = description.key + ".{}"
+        entity_id_format = "sensor.{}"
 
         self._attr_unique_id = (
             f"{self.coordinator.location_name},{description.key}".lower()


### PR DESCRIPTION
Fixes issue where sensors fail to load in HA 2026.2+ with:
\\\HomeAssistantError: Invalid entity ID: validTimeLocal.home_forecast_description_updated_time\\\`n
The problem was in sensor.py line 88 where \entity_id_format\ was using the sensor key as the domain instead of hardcoding 'sensor'. Changed from:
\\\python
entity_id_format = description.key + '.{}'\\\`nto:
\\\python
entity_id_format = 'sensor.{}'\\\`n
Tested on HA 2026.2.0 - all sensors now load correctly.