### PR TITLE
Fixes #154. Invalid entity errors

### DIFF
--- a/custom_components/metservice_weather/sensor.py
+++ b/custom_components/metservice_weather/sensor.py
@@ -11,7 +11,6 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import generate_entity_id
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity

--- a/custom_components/metservice_weather/sensor.py
+++ b/custom_components/metservice_weather/sensor.py
@@ -86,16 +86,8 @@ class WeatherSensor(CoordinatorEntity, SensorEntity):
             name=coordinator.location_name,
             manufacturer=MANUFACTURER,
         )
-
-        entity_id_format = description.key + ".{}"
-
         self._attr_unique_id = (
             f"{self.coordinator.location_name},{description.key}".lower()
-        )
-        self.entity_id = generate_entity_id(
-            entity_id_format,
-            f"{self.coordinator.location_name}_{description.name}",
-            hass=coordinator.hass,
         )
         self._unit_system = coordinator.unit_system
         if self.coordinator.api_type == 'mobile':


### PR DESCRIPTION
Fixes #154. Invalid entity_id errors due to Home Assistant new requirement for all sensors to begin with the "sensor." domain.

Removed the static formatting to allow integration to adopt the current sensor naming format. During verification I didn't have any orphaned entities (after entity_id changed), so unique_id anchors correctly.

NOTE: After fix users will need to update their dashboards/integrations.